### PR TITLE
docs: Add placeholder privacy policy

### DIFF
--- a/app/src/main/assets/privacy_policy.txt
+++ b/app/src/main/assets/privacy_policy.txt
@@ -1,0 +1,29 @@
+Privacy Policy for LeFauxPass
+
+Last updated: August 17, 2025
+
+This Privacy Policy describes Our policies and procedures on the collection, use and disclosure of your information when You use the Service and tells You about Your privacy rights and how the law protects You.
+
+Information Collection and Use
+================================
+
+LeFauxPass is a standalone application that does not collect, store, or transmit any personal information or data from your device. All functionality of the app is performed locally on your device. We do not have access to any of your data.
+
+Permissions
+===========
+
+LeFauxPass does not request any special permissions to run.
+
+Changes to this Privacy Policy
+==============================
+
+We may update Our Privacy Policy from time to time. We will notify You of any changes by posting the new Privacy Policy on this page.
+
+You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page.
+
+Contact Us
+==========
+
+If you have any questions about this Privacy Policy, You can contact us:
+
+* By email: [Your Contact Email Here]


### PR DESCRIPTION
Adds a placeholder privacy policy to the application. The policy clearly states that the app does not collect, store, or transmit any user data, as per the application's functionality.

## Summary by Sourcery

Add a placeholder privacy policy asset and enhance the ticket screen to display a loading spinner until the video animation is ready

New Features:
- Include a placeholder privacy policy file stating no user data is collected, stored, or transmitted

Enhancements:
- Revamp RtaTicketScreen layout to use Box for centering and conditional alpha based on video readiness
- Introduce isVideoReady state with a CircularProgressIndicator overlay until the video is ready
- Extend VideoPlayer composable with an onReady callback and playback state listener to signal readiness

Documentation:
- Add privacy_policy.txt to assets as the app’s placeholder privacy policy