### PR TITLE
docs: Add privacy policy to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# LeFauxPass Privacy Policy
+
+**Last updated: August 17, 2025**
+
+This Privacy Policy describes Our policies and procedures on the collection, use and disclosure of your information when You use the Service and tells You about Your privacy rights and how the law protects You.
+
+## Information Collection and Use
+
+LeFauxPass is a standalone application that **does not collect, store, or transmit any personal information or data** from your device. All functionality of the app is performed locally on your device. We do not have access to any of your data.
+
+## Permissions
+
+LeFauxPass does not request any special permissions to run.
+
+## Changes to this Privacy Policy
+
+We may update Our Privacy Policy from time to time. We will notify You of any changes by posting the new Privacy Policy on this page.
+
+You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page.
+
+## Contact Us
+
+If you have any questions about this Privacy Policy, You can contact us:
+
+*   By email: `[Your Contact Email Here]`


### PR DESCRIPTION
Replaces the previous text-based privacy policy with a markdown version in the main README.md file. The policy states that the app does not collect any user data.

## Summary by Sourcery

Improve the ticket screen UX by refactoring its layout and adding video readiness handling with a loading indicator, and document the app’s privacy policy in the README.

New Features:
- Add a loading indicator that displays until the video animation is ready
- Introduce an onReady callback in VideoPlayer to signal when playback is ready

Enhancements:
- Refactor RtaTicketScreen to use a Box layout and alpha-based visibility controlled by isVideoReady state
- Update VideoPlayer to listen for playback state changes and notify the onReady callback

Documentation:
- Add a markdown-formatted privacy policy to README.md stating that the app does not collect any user data